### PR TITLE
show event end time on schedule

### DIFF
--- a/app/src/components/events/EventCell.tsx
+++ b/app/src/components/events/EventCell.tsx
@@ -36,14 +36,31 @@ export default function EventCell({
           className={`table-cell w-0/12 px-1 bg-[${event.color}] rounded-sm`}
         />
         <div className="text-center items-center table-cell w-1/12 px-3 align-middle">
-          {timeDisplayParts(event.begin).map((part) => (
-            <p
-              key={part}
-              className="text-xs sm:text-sm md:text-sm lg:text-base font-bold text-dc-text"
-            >
-              {part}
-            </p>
-          ))}
+          {timeDisplayParts(event.begin, event.begin === event.end).map(
+            (part) => (
+              <p
+                key={part}
+                className="text-xs sm:text-sm md:text-sm lg:text-base font-bold text-dc-text"
+              >
+                {part}
+              </p>
+            )
+          )}
+          {event.begin !== event.end && (
+            <>
+              <p className="text-xs sm:text-sm md:text-sm lg:text-base font-bold text-dc-text text-gray-400 leading-3 sm:leading-3 md:leading-3 lg:leading-3">
+                -
+              </p>
+              {timeDisplayParts(event.end, true).map((part) => (
+                <p
+                  key={part}
+                  className="text-xs sm:text-sm md:text-sm lg:text-base font-bold text-dc-text"
+                >
+                  {part}
+                </p>
+              ))}
+            </>
+          )}
         </div>
         <div className="w-10/12 table-cell pr-1">
           <Link href={`/event?id=${event.id}`} prefetch={false}>

--- a/app/src/components/events/EventCell.tsx
+++ b/app/src/components/events/EventCell.tsx
@@ -48,13 +48,13 @@ export default function EventCell({
           )}
           {event.begin !== event.end && (
             <>
-              <p className="text-xs sm:text-sm md:text-sm lg:text-base font-bold text-dc-text text-gray-400 leading-3 sm:leading-3 md:leading-3 lg:leading-3">
+              <p className="text-xs sm:text-xs md:text-xs lg:text-sm font-light text-dc-text text-gray-400 leading-3 sm:leading-3 md:leading-3 lg:leading-3">
                 -
               </p>
               {timeDisplayParts(event.end, true).map((part) => (
                 <p
                   key={part}
-                  className="text-xs sm:text-sm md:text-sm lg:text-base font-bold text-dc-text"
+                  className="text-xs sm:text-xs md:text-xs lg:text-sm font-light text-dc-text text-gray-400"
                 >
                   {part}
                 </p>

--- a/app/src/utils/dates.ts
+++ b/app/src/utils/dates.ts
@@ -4,7 +4,7 @@ export function timeDisplayParts(time: string): string[] {
     hour: "numeric",
     minute: "numeric",
     timeZoneName: "short",
-    hour12: false,
+    hourCycle: "h23",
     timeZone: "America/Los_Angeles",
   };
 
@@ -17,7 +17,7 @@ export function eventDay(time: Date): string {
     day: "numeric",
     year: "numeric",
     month: "numeric",
-    hour12: false,
+    hourCycle: "h23",
     timeZone: "America/Los_Angeles",
   };
 
@@ -38,7 +38,7 @@ export function newsDate(s: number): string {
     month: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-    hour12: false,
+    hourCycle: "h23",
     timeZoneName: "short",
     timeZone: "America/Los_Angeles",
   };
@@ -92,7 +92,7 @@ export function eventTime(time: Date, tz = true): string {
   const options: Intl.DateTimeFormatOptions = {
     timeZoneName: tz ? "short" : undefined,
     weekday: "short",
-    hour12: false,
+    hourCycle: "h23",
     day: "numeric",
     month: "short",
     hour: "2-digit",

--- a/app/src/utils/dates.ts
+++ b/app/src/utils/dates.ts
@@ -1,9 +1,9 @@
-export function timeDisplayParts(time: string): string[] {
+export function timeDisplayParts(time: string, tz = true): string[] {
   const date = new Date(time);
   const options: Intl.DateTimeFormatOptions = {
     hour: "numeric",
     minute: "numeric",
-    timeZoneName: "short",
+    timeZoneName: tz ? "short" : undefined,
     hourCycle: "h23",
     timeZone: "America/Los_Angeles",
   };


### PR DESCRIPTION
At DEF CON this year I found it inconvenient to have to click into an event to see when it ends. I wanted to prioritize events like talks that lasts around an hour, over events like CTFs that last all day which I can go check out later. This PR adds the end times of the events in schedule.

In addition I noticed that on chrome 00:00 is displayed as 24:00. I think it's more common to have 00:00.

I have also made PRs for this feature for the iOS and Android version: [PR for iOS](https://github.com/BeezleLabs/hackertracker/pull/6), [PR for Android](https://github.com/Advice-Dog/Schedule/pull/7).

Screenshots from Chrome:

| Before | After |
|---|---|
|![localhost_3000_events_(iPhone 12 Pro) (1)](https://github.com/BeezleLabs/hackertracker-info/assets/8357970/87c3df47-53f4-4ab1-aa33-70ddfa2fc5cd)|![localhost_3000_events_(iPhone 12 Pro) (2)](https://github.com/BeezleLabs/hackertracker-info/assets/8357970/77368645-7556-4296-ae37-60d2bfa5d98b)|
