### PR TITLE
Post-launch UI & Sorting Polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-navigation-menu": "^1.2.13",
+        "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -277,6 +278,44 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
+      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@gsap/react": {
       "version": "2.1.2",
@@ -1021,6 +1060,12 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
@@ -1042,6 +1087,29 @@
         "@radix-ui/react-id": "1.1.1",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1352,6 +1420,38 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.7.tgz",
+      "integrity": "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
@@ -1438,6 +1538,49 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.5.tgz",
+      "integrity": "sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1643,6 +1786,42 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-visually-hidden": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
@@ -1665,6 +1844,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-navigation-menu": "^1.2.13",
+    "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/components/heading/Heading.tsx
+++ b/src/components/heading/Heading.tsx
@@ -33,7 +33,7 @@ const RAW_MENU = [
     sort_order: 2,
     title: "Content",
     href: "/content",
-    description: "Explore all talks, tags, and sessions by category.",
+    description: "Explore all content for DEF CON 33.",
     icon: ListBulletIcon,
   },
   {

--- a/src/components/people/person.tsx
+++ b/src/components/people/person.tsx
@@ -15,10 +15,7 @@ import { Person } from "@/types/info";
 
 export default function PersonDisplay({ person }: { person: Person }) {
   // derive avatar initials
-  const initials = person.name
-    .split(" ")
-    .map((n) => n[0])
-    .join("");
+  const initials = person.name.charAt(0);
 
   const avatarUrl = person.media.find((p) => p.sort_order === 1)?.url || "";
 

--- a/src/components/schedule/Events.tsx
+++ b/src/components/schedule/Events.tsx
@@ -72,7 +72,11 @@ export default function Events({
       <div className="sticky top-0 bg-background z-40 p-2 border-b border-gray-700 flex gap-2 justify-end">
         <div className="flex gap-2">
           <Link href="/bookmarks">
-            <Button variant="ghost" size="icon" aria-label="Filter by books">
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Filter by bookmarks"
+            >
               <Bookmark />
             </Button>
           </Link>

--- a/src/components/tags/Tags.tsx
+++ b/src/components/tags/Tags.tsx
@@ -26,9 +26,7 @@ export default function Tags({ tagTypes }: { tagTypes: TagType[] }) {
     return tagTypes
       .filter(
         (tt) =>
-          tt.is_browsable &&
-          tt.is_single_valued &&
-          tt.label === "Event Category"
+          tt.is_browsable && tt.tags.length > 0 && tt.category == "content"
       )
       .reduce<Record<string, TagType[]>>((acc, tt) => {
         acc[tt.category] = acc[tt.category] || [];

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,183 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/lib/misc.ts
+++ b/src/lib/misc.ts
@@ -1,31 +1,12 @@
 export const fetcher = async (...args: Parameters<typeof fetch>) =>
   await fetch(...args).then(async (res) => await res.json());
 
-const sortSpeakers = (a: Speaker, b: Speaker) => {
-  if (a.name.toLowerCase() > b.name.toLowerCase()) {
-    return 1;
-  }
+function cleanForSort(str: string): string {
+  return str.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
 
-  if (a.name.toLowerCase() < b.name.toLowerCase()) {
-    return -1;
-  }
-
-  return 0;
-};
-
-const groupedSpeakers = (speakers: Speaker[]): Map<string, Speaker[]> =>
-  speakers.sort(sortSpeakers).reduce((group, s) => {
-    const firstLetter = s.name.toLowerCase()[0] ?? "";
-    const iSpeakers = group.get(firstLetter) ?? [];
-    iSpeakers.push(s);
-    group.set(firstLetter, iSpeakers);
-    return group;
-  }, new Map<string, Speaker[]>());
-
-export const createSpeakerGroup = (speakers: Speaker[]) =>
-  new Map(
-    Array.from(groupedSpeakers(speakers)).map(([d, et]) => [
-      d,
-      et.sort(sortSpeakers),
-    ])
-  );
+export function alphaSort(a: string, b: string): number {
+  const cleanA = cleanForSort(a);
+  const cleanB = cleanForSort(b);
+  return cleanA.localeCompare(cleanB);
+}

--- a/src/pages/communities/index.tsx
+++ b/src/pages/communities/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import useSWR from "swr";
 import Head from "next/head";
-import { fetcher } from "@/lib/misc";
+import { alphaSort, fetcher } from "@/lib/misc";
 import Loading from "@/components/misc/Loading";
 import Error from "@/components/misc/Error";
 import Heading from "@/components/heading/Heading";
@@ -18,9 +18,11 @@ export default function CommunitiesPage() {
   if (isLoading) return <Loading />;
   if (error || !organizations) return <Error />;
 
-  const communities = organizations.filter((org) =>
-    org.tag_ids.includes(47621)
-  );
+  const communities = organizations
+    .filter((org) => org.tag_ids.includes(47621))
+    .sort((a, b) => {
+      return alphaSort(a.name, b.name);
+    });
 
   return (
     <>

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -9,7 +9,11 @@ import ContentList from "@/components/content/ContentList";
 import ContentDetail from "@/components/content/ContentDetail";
 import Head from "next/head";
 import { useSearchParams } from "next/navigation";
-import type { ProcessedContent, ProcessedContents } from "@/types/info";
+import type {
+  ProcessedContent,
+  ProcessedContents,
+  TagTypes,
+} from "@/types/info";
 
 export default function ContentPage() {
   const params = useSearchParams();
@@ -25,15 +29,23 @@ export default function ContentPage() {
     isLoading,
   } = useSWR<ProcessedContents>("/ht/processedContent.json", fetcher);
 
+  const {
+    data: tags,
+    error: tagError,
+    isLoading: tagIsLoading,
+  } = useSWR<TagTypes>("/ht/tagTypes.json", fetcher);
+
   const selectedContent = useMemo<ProcessedContent | null>(() => {
     if (!items || contentId === null) return null;
     return items.find((c) => c.id === contentId) ?? null;
   }, [items, contentId]);
 
-  if (isLoading) return <Loading />;
+  if (isLoading || tagIsLoading) return <Loading />;
   if (error) return <Error msg="Failed to load content" />;
   if (contentId !== null && !selectedContent)
     return <Error msg="Content not found" />;
+
+  if (tagError) return <Error msg="Failed to load tags" />;
 
   return (
     <>
@@ -57,7 +69,7 @@ export default function ContentPage() {
         {selectedContent ? (
           <ContentDetail content={selectedContent} />
         ) : (
-          <ContentList content={items!} />
+          <ContentList content={items!} tags={tags ?? []} />
         )}
       </main>
     </>

--- a/src/pages/contests/index.tsx
+++ b/src/pages/contests/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import useSWR from "swr";
 import Head from "next/head";
-import { fetcher } from "@/lib/misc";
+import { alphaSort, fetcher } from "@/lib/misc";
 import Loading from "@/components/misc/Loading";
 import Error from "@/components/misc/Error";
 import Heading from "@/components/heading/Heading";
@@ -18,7 +18,11 @@ export default function ContestsPage() {
   if (isLoading) return <Loading />;
   if (error || !organizations) return <Error />;
 
-  const contests = organizations.filter((org) => org.tag_ids.includes(47622));
+  const contests = organizations
+    .filter((org) => org.tag_ids.includes(47622))
+    .sort((a, b) => {
+      return alphaSort(a.name, b.name);
+    });
 
   return (
     <>

--- a/src/pages/maps/index.tsx
+++ b/src/pages/maps/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import Heading from "@/components/heading/Heading";
+import Head from "next/head";
+
+export default function MapsPage() {
+  return (
+    <>
+      <Head>
+        <title>Maps | DEF CON</title>
+        <meta name="description" content="DEF CON 33 Maps" />
+      </Head>
+      <main>
+        <Heading />
+        {/* Placeholder for maps content */}
+        <div>
+          <h1 className="text-3xl font-bold mb-6 mt-10 mx-10">Maps</h1>
+          <div className="flex justify-center mt-10">
+            <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-green-400" />
+            <pre className="bg-black text-green-400 font-mono p-4 rounded mx-10 mt-6 text-sm shadow-md">
+              {`> Initiating geospatial subroutine...
+> Decoding SIGINT...
+> Searching for: Las Vegas Convention Center layout...
+> Access denied.
+> Retrying...
+> Retrying...
+> Access granted.
+> Rendering map...
+
+> Stay tuned for the official DEF CON 33 maps, coming soon!`}
+            </pre>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/pages/villages/index.tsx
+++ b/src/pages/villages/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import useSWR from "swr";
 import Head from "next/head";
-import { fetcher } from "@/lib/misc";
+import { alphaSort, fetcher } from "@/lib/misc";
 import Loading from "@/components/misc/Loading";
 import Error from "@/components/misc/Error";
 import Heading from "@/components/heading/Heading";
@@ -18,7 +18,11 @@ export default function VillagesPage() {
   if (isLoading) return <Loading />;
   if (error || !organizations) return <Error />;
 
-  const villages = organizations.filter((org) => org.tag_ids.includes(47614));
+  const villages = organizations
+    .filter((org) => org.tag_ids.includes(47614))
+    .sort((a, b) => {
+      return alphaSort(a.name, b.name);
+    });
 
   return (
     <>


### PR DESCRIPTION
This PR includes a batch of non-blocking fixes and UI polish tasks identified after initial deployment of the DC33 site:

#### ✅ Changes:

* Enforced **alphabetical sorting** on:

  * `/villages`
  * `/communities`
  * `/contests`
* Applied **character stripping for sorting** (e.g., quotes, special characters) on:

  * `/people`
  * `/content`
* Improved `/content` usability by checking for **filtering capabilities**
* Refined **placeholder initials** for people with nicknames (e.g., no more `J"L`)
* Ensured `/maps` handles **missing data gracefully**:

  * No 404s
  * Placeholder added
  * Persistent site nav/menu even when no maps are available
