### PR TITLE
Fix stale detail routes and scroll restoration

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,6 +10,8 @@ import { useConferenceRouteParam } from "@/lib/hooks/useConferenceRouteParam";
 import { CONFERENCE_ROUTE_DEFINITIONS, type ConferenceRouteKey } from "@/lib/routes";
 import { PageId } from "@/lib/types/page-meta";
 
+import AppScrollRestoration from "./AppScrollRestoration";
+
 const HomePage = lazy(() => import("@/routes/HomePage"));
 const TVPage = lazy(() => import("@/routes/TVPage"));
 const AnnouncementsPage = lazy(() => import("@/routes/conference/AnnouncementsPage"));
@@ -132,6 +134,7 @@ function RouteLoadingFallback() {
 export default function App() {
   return (
     <BrowserRouter>
+      <AppScrollRestoration />
       <AppErrorBoundary>
         <Suspense fallback={<RouteLoadingFallback />}>
           <Routes>

--- a/src/app/AppScrollRestoration.tsx
+++ b/src/app/AppScrollRestoration.tsx
@@ -1,0 +1,134 @@
+import { useLayoutEffect, useRef } from "react";
+import { useLocation, useNavigationType } from "react-router";
+
+type RouteSnapshot = {
+  key: string;
+  pathname: string;
+  search: string;
+  hash: string;
+};
+
+type ScrollPosition = {
+  x: number;
+  y: number;
+};
+
+function getQueryId(search: string) {
+  return new URLSearchParams(search).get("id");
+}
+
+function hasQueryId(search: string) {
+  return new URLSearchParams(search).has("id");
+}
+
+function shouldResetScroll(previous: RouteSnapshot | null, current: RouteSnapshot) {
+  if (!previous) return true;
+  if (current.hash && current.hash !== previous.hash) return true;
+  if (current.pathname !== previous.pathname) return true;
+
+  return getQueryId(current.search) !== getQueryId(previous.search);
+}
+
+function scrollToHash(hash: string) {
+  let frameId = 0;
+  const expiresAt = performance.now() + 2_000;
+  const id = decodeURIComponent(hash.slice(1));
+
+  const scrollIfReady = () => {
+    const element = document.getElementById(id);
+    if (element) {
+      element.scrollIntoView();
+      return;
+    }
+
+    if (performance.now() < expiresAt) {
+      frameId = window.requestAnimationFrame(scrollIfReady);
+    }
+  };
+
+  scrollIfReady();
+
+  return () => {
+    if (frameId) {
+      window.cancelAnimationFrame(frameId);
+    }
+  };
+}
+
+function scrollToLocationTarget(location: RouteSnapshot) {
+  if (!location.hash) {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    return undefined;
+  }
+
+  try {
+    const cancelHashScroll = scrollToHash(location.hash);
+    return cancelHashScroll;
+  } catch {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    return undefined;
+  }
+}
+
+function toSnapshot(location: RouteSnapshot): RouteSnapshot {
+  return {
+    key: location.key,
+    pathname: location.pathname,
+    search: location.search,
+    hash: location.hash,
+  };
+}
+
+export default function AppScrollRestoration() {
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  const previousLocationRef = useRef<RouteSnapshot | null>(null);
+  const scrollPositionsRef = useRef(new Map<string, ScrollPosition>());
+
+  useLayoutEffect(() => {
+    if (!("scrollRestoration" in window.history)) return undefined;
+
+    const previousScrollRestoration = window.history.scrollRestoration;
+    window.history.scrollRestoration = "manual";
+
+    return () => {
+      window.history.scrollRestoration = previousScrollRestoration;
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const currentLocation = toSnapshot(location);
+    const previousLocation = previousLocationRef.current;
+    const scrollPositions = scrollPositionsRef.current;
+    const isDetailRoute = hasQueryId(currentLocation.search);
+    let cancelPendingScroll: (() => void) | undefined;
+
+    if (navigationType === "POP" && !isDetailRoute) {
+      const savedPosition = scrollPositions.get(currentLocation.key);
+
+      if (savedPosition) {
+        window.scrollTo({
+          top: savedPosition.y,
+          left: savedPosition.x,
+          behavior: "auto",
+        });
+      } else if (shouldResetScroll(previousLocation, currentLocation)) {
+        cancelPendingScroll = scrollToLocationTarget(currentLocation);
+      }
+    } else if (shouldResetScroll(previousLocation, currentLocation)) {
+      cancelPendingScroll = scrollToLocationTarget(currentLocation);
+    }
+
+    previousLocationRef.current = currentLocation;
+
+    return () => {
+      scrollPositions.set(currentLocation.key, {
+        x: window.scrollX,
+        y: window.scrollY,
+      });
+      cancelPendingScroll?.();
+    };
+  }, [location, navigationType]);
+
+  return null;
+}

--- a/src/features/organizations/DirectoryPage.tsx
+++ b/src/features/organizations/DirectoryPage.tsx
@@ -120,7 +120,11 @@ export default function DirectoryPage({
 
     pageContent = (
       <ConferenceLayout conference={conf} activePageId={activePageId}>
-        <OrganizationDetails org={selectedOrganization} conference={conf} />
+        <OrganizationDetails
+          key={selectedOrganization.id}
+          org={selectedOrganization}
+          conference={conf}
+        />
       </ConferenceLayout>
     );
   } else if (isIdMissing) {

--- a/src/routes/conference/ContentPage.tsx
+++ b/src/routes/conference/ContentPage.tsx
@@ -143,6 +143,7 @@ export default function ContentPage({ conf, activePageId }: ContentPageProps) {
     pageDescription = metaDescription;
     pageContent = (
       <ContentDetails
+        key={content.id}
         content={content}
         sessions={sessions}
         locations={locations}

--- a/src/routes/conference/DocumentPage.tsx
+++ b/src/routes/conference/DocumentPage.tsx
@@ -61,7 +61,7 @@ export default function DocumentPage({ conf, activePageId }: DocumentPageProps) 
         <meta name="description" content={`Reference document for ${conf.name}.`} />
       </Head>
       <ConferenceLayout conference={conf} activePageId={activePageId}>
-        <DocumentDetails document={selectedDocument} conference={conf} />
+        <DocumentDetails key={selectedDocument.id} document={selectedDocument} conference={conf} />
       </ConferenceLayout>
     </>
   );

--- a/src/routes/conference/OrganizationPage.tsx
+++ b/src/routes/conference/OrganizationPage.tsx
@@ -49,7 +49,7 @@ export default function OrganizationPage({ conf, activePageId }: OrganizationPag
         <meta name="description" content={description} />
       </Head>
       <ConferenceLayout conference={conf} activePageId={activePageId}>
-        <OrganizationDetails org={organization} conference={conf} />
+        <OrganizationDetails key={organization.id} org={organization} conference={conf} />
       </ConferenceLayout>
     </>
   );

--- a/src/routes/conference/PeoplePage.tsx
+++ b/src/routes/conference/PeoplePage.tsx
@@ -110,6 +110,7 @@ export default function PeoplePage({ conf, activePageId }: PeoplePageProps) {
     pageDescription = metaDescription;
     pageContent = (
       <PersonDetails
+        key={person.id}
         person={person}
         events={eventForContentIds}
         locations={locationsForEventIds}

--- a/src/routes/conference/TagPage.tsx
+++ b/src/routes/conference/TagPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback } from "react";
+import React, { useEffect, useMemo, useState, useCallback } from "react";
 import { Link } from "react-router";
 
 import Head from "@/components/Head";
@@ -241,6 +241,10 @@ export default function TagPage({ conf, activePageId }: TagPageProps) {
 
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
 
+  useEffect(() => {
+    setSelectedDay(null);
+  }, [tagId]);
+
   const resolvedDay = useMemo(() => {
     if (selectedDay && days.some(({ day }) => day === selectedDay)) {
       return selectedDay;
@@ -288,6 +292,7 @@ export default function TagPage({ conf, activePageId }: TagPageProps) {
         </h1>
         {days.length > 0 && resolvedDay ? (
           <ScheduleEvents
+            key={tag.id}
             conf={conf}
             days={days}
             selectedDay={resolvedDay}


### PR DESCRIPTION
## Summary

Fixes stale detail rendering and incorrect scroll position behavior when navigating between entity detail pages that reuse the same React Router route with different `?id=` values.

This specifically addresses the reported villages issue where selecting one village, returning to the list, and selecting another village could appear to show the wrong village or open a long description partway down the page.

## Root Cause

The selected village lookup was correct. The issue was route/component reuse and scroll state.

`/defcon34/villages` and `/defcon34/villages?id=<id>` share the same React Router route instance. When only the query string changed, React reused the existing detail component, and the browser preserved the prior document scroll position. That meant a long detail page could open mid-description and look stale or incorrect.

The same pattern could affect other `?id=` detail pages beyond villages.

## Changes

- Added global app scroll restoration via `AppScrollRestoration`.
- Mounted scroll restoration under `BrowserRouter`.
- Reset scroll to top on path changes.
- Reset scroll to top when `?id=` changes.
- Preserve browser back/forward scroll position for non-detail list pages.
- Keep `?id=` detail pages starting at the top, including browser back/forward navigation.
- Respect hash links and retry briefly for async-rendered content.
- Avoid interfering with non-detail query changes such as `schedule?day=`.
- Keyed detail components by entity ID so React remounts them when navigating between different detail entities.
- Reset tag selected-day state when the tag ID changes.
- Keyed tag schedule rendering by tag ID.

## Files Changed

- `src/app/App.tsx`
- `src/app/AppScrollRestoration.tsx`
- `src/features/organizations/DirectoryPage.tsx`
- `src/routes/conference/OrganizationPage.tsx`
- `src/routes/conference/ContentPage.tsx`
- `src/routes/conference/PeoplePage.tsx`
- `src/routes/conference/DocumentPage.tsx`
- `src/routes/conference/TagPage.tsx`

## Detail Route Fixes

The following routes now avoid stale component state when navigating between entities:

- Organization directory/details: `OrganizationDetails key={id}`
- Generic organization route: `OrganizationDetails key={id}`
- Content details: `ContentDetails key={id}`
- People/speakers details: `PersonDetails key={id}`
- Document details: `DocumentDetails key={id}`
- Tag schedule route: resets `selectedDay` on `tagId` change and keys `ScheduleEvents` by `tag.id`

## Validation

- Navigating from the villages list to a village detail page opens at the top.
- Returning to the villages list and selecting another village shows the correct village.
- Long village descriptions no longer open at the previous scroll position.
- Browser back/forward restores scroll position for list-style pages.
- Detail pages using `?id=` still open at the top.
- Hash links continue to scroll to the intended target.
- Schedule day navigation is left to the existing schedule-specific behavior.